### PR TITLE
Fixing some minor issues which could be discovered using clang trunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ Tool to automatically search for linear characteristics. There exists a research
 paper about this tool called "Heuristic Tool for Linear Cryptanalysis with
 Applications to CAESAR Candidates", which is presented at AsiaCrypt 2015, an
 online version is available [here](https://eprint.iacr.org/2015/1200). If you
-use this tool in your work, we would be nice to cite the research paper.
+use this tool in your work, it would be nice to cite the research paper.
 
 Authors
 -------
-
-Christoph Dobraunig (christoph.dobraunig@iaik.tugraz.at)
-Maria Eichlseder (maria.eichlseder@iaik.tugraz.at)
-Florian Mendel (florian.mendel@iaik.tugraz.at)
+- Christoph Dobraunig (<christoph.dobraunig@iaik.tugraz.at>)
+- Maria Eichlseder (<maria.eichlseder@iaik.tugraz.at>)
+- Florian Mendel (<florian.mendel@iaik.tugraz.at>)
 
 Build
 -----
@@ -40,9 +39,11 @@ Keyak, Minalpher and Proest. To start a search simply call for instance:
 ./lin -I 10 -S 2 -i examples/ascon_3_rounds_typeI.xml
 ```
 
--I determines how often status information of the search is displayed. -I -1 deactivates it.
--S determines how often the current and probably partial determined linear characteristic is put out. -S -1 deactivates it.
--i specifies the used xml based search file.
+* `-I` determines how often status information of the search is displayed.
+  `-I -1` deactivates it.
+* `-S` determines how often the current and probably partial determined linear
+  characteristic is put out. `-S -1` deactivates it.
+* `-i` specifies the used xml based search file.
 
 The output of the search are linear characteristics, where Round 0 tags the
 linear mask of the input of the first round, Round 1 the output of the first
@@ -54,6 +55,7 @@ layer.
 
 A search file looks like follows:
 
+```
 <config>
 <parameters>
   <permutation value="ascon"/>
@@ -117,22 +119,42 @@ A search file looks like follows:
   </phase>
 </search>
 </config>
+```
 
+In this file, the field `char value` contains the starting point of the search,
+where all intermediate masks are considered. Incomplete starting points are
+padded with '?'.
 
-In this file, the field "char value" contains the starting point of the search, where all intermediate masks are considered. Incomplete starting points are padded with '?'.
+The field `credits` determines, how often a contradiction during the search is
+backtracked until the current search is re-started. To provide a clear view, the
+search only prints better characteristics than already found. With
+`print_active` it is determined whether this "best" metric targets active
+S-boxes or the bias.
 
-The field "credits" determines, how often a contradiction during the search is backtracked until the current search is re-started. To provide a clear view, the search only prints better characteristics than already found. With "print_active" it is determined whether this "best" metric targets active S-boxes or the bias.
+Settings define which S-boxes are guessed and are treated subsequently. So if
+there is no guessable S-box in a current setting, the next one is taken.
+`push_stack` defines the probability that the current characteristic is pushed
+to the stack for a possible later backtracking. `alternative_sbox_guesses`
+defines how many other contradicting assignments of linear masks than the best
+one defined according to `sbox_weight_probability` and `sbox_weight_hamming`
+have to be taken into account until the characteristic is treaded as impossible.
+`sbox_weight_probability` and `sbox_weight_hamming` are used to rate masks for
+S-boxes. A high value for `sbox_weight_probability` prefers masks that have a
+high bias, whereas a high value `sbox_weight_hamming` prefers masks that have a
+low hamming weight.
 
-Settings define which S-boxes are guessed and are treated subsequently. So if there is no guessable S-box in a current setting, the next one is taken. "push_stack" defines the probability that the current characteristic is pushed to the stack for a possible later backtracking. "alternative_sbox_guesses" defines how many other contradicting assignments of linear masks than the best one defined according to "sbox_weight_probability" and "sbox_weight_hamming" have to be taken into account until the characteristic is treaded as impossible. "sbox_weight_probability" and "sbox_weight_hamming" are used to rate masks for S-boxes. A high value for "sbox_weight_probability" prefers masks that have a high bias, whereas a high value "sbox_weight_hamming" prefers masks that have a low hamming weight.
+`active_weight` determines the probability that an active S-box will be guessed
+(higher values mean higher chance). `inactive_weight` does the same for inactive
+S-boxes.
 
-"active_weight" determines the probability that an active S-box will be guessed (higher values mean higher chance). inactive_weight does the same for inactive S-boxes.
-
-The code snippets describing the behavior of the linear and S-box layer of the implemented ciphers are taken from their reference implementations, which are
-available at http://bench.cr.yp.to/ebash.html.
+The code snippets describing the behavior of the linear and S-box layer of the
+implemented ciphers are taken from their reference implementations, which are
+available at <http://bench.cr.yp.to/ebash.html>.
 
 The tool is tested under
 - Xubuntu 14.04 (64 bit) using gcc version 4.8.2
+- Xubuntu 14.10 (64 bit) using gcc version 4.9.1
+- Xubuntu 14.10 (64 bit) using clang (3.8 trunk, Revision 254516)
 - Ubuntu 15.04 (64 bit) using gcc version 4.9.2
 - OSX Yosemite using Apple LLVM version 6.0
-
 

--- a/target/ascon_permutation.cpp
+++ b/target/ascon_permutation.cpp
@@ -74,7 +74,8 @@ Permutation::PermPtr AsconPermutation::clone() const {
   return PermPtr(new AsconPermutation(*this));
 }
 
-void AsconPermutation::PrintWithProbability(std::ostream& stream, int offset) {
+void AsconPermutation::PrintWithProbability(std::ostream& stream,
+                                            unsigned int offset) {
   Permutation::PrintWithProbability(stream, 0);
 }
 

--- a/target/ascon_permutation.h
+++ b/target/ascon_permutation.h
@@ -40,7 +40,7 @@ struct AsconPermutation : public Permutation {
   void touchall();
   PermPtr clone() const;
   virtual void PrintWithProbability(std::ostream& stream = std::cout,
-                                    int offset = 0);
+                                    unsigned int offset = 0) override;
 
 };
 

--- a/target/icepole_permutation.cpp
+++ b/target/icepole_permutation.cpp
@@ -126,7 +126,8 @@ Permutation::PermPtr IcepolePermutation::clone() const {
 }
 
 
-void IcepolePermutation::PrintWithProbability(std::ostream& stream, int offset) {
+void IcepolePermutation::PrintWithProbability(std::ostream& stream,
+                                              unsigned int offset) {
   Permutation::PrintWithProbability(stream, 1);
 }
 

--- a/target/icepole_permutation.h
+++ b/target/icepole_permutation.h
@@ -17,7 +17,8 @@ struct IcepolePermutation : public Permutation {
   bool update();
   void touchall();
   PermPtr clone() const;
-  virtual void PrintWithProbability(std::ostream& stream = std::cout, int offset = 0);
+  virtual void PrintWithProbability(std::ostream& stream = std::cout,
+                                    unsigned int offset = 0) override;
 
 };
 

--- a/target/keccak1600_permutation.cpp
+++ b/target/keccak1600_permutation.cpp
@@ -126,7 +126,8 @@ Permutation::PermPtr Keccak1600Permutation::clone() const {
 }
 
 
-void Keccak1600Permutation::PrintWithProbability(std::ostream& stream, int offset) {
+void Keccak1600Permutation::PrintWithProbability(std::ostream& stream,
+                                                 unsigned int offset) {
   Permutation::PrintWithProbability(stream, 1);
 }
 

--- a/target/keccak1600_permutation.h
+++ b/target/keccak1600_permutation.h
@@ -17,7 +17,8 @@ struct Keccak1600Permutation : public Permutation {
   bool update();
   void touchall();
   PermPtr clone() const;
-  virtual void PrintWithProbability(std::ostream& stream = std::cout, int offset = 0);
+  virtual void PrintWithProbability(std::ostream& stream = std::cout,
+                                    unsigned int offset = 0) override;
 
 };
 

--- a/target/prost256_permutation.cpp
+++ b/target/prost256_permutation.cpp
@@ -66,7 +66,8 @@ Permutation::PermPtr Prost256Permutation::clone() const {
 }
 
 
-void Prost256Permutation::PrintWithProbability(std::ostream& stream, int offset) {
+void Prost256Permutation::PrintWithProbability(std::ostream& stream,
+                                               unsigned int offset) {
   Permutation::PrintWithProbability(stream, 0);
 }
 

--- a/target/prost256_permutation.h
+++ b/target/prost256_permutation.h
@@ -15,7 +15,8 @@ struct Prost256Permutation : public Permutation {
   Prost256Permutation(const Prost256Permutation& other);
   void touchall();
   PermPtr clone() const;
-  virtual void PrintWithProbability(std::ostream& stream = std::cout, int offset = 0);
+  virtual void PrintWithProbability(std::ostream& stream = std::cout,
+                                    unsigned int offset = 0) override;
 
 };
 

--- a/tool/commandlineparser.cpp
+++ b/tool/commandlineparser.cpp
@@ -64,7 +64,7 @@ float Commandlineparser::getFloatParameter(std::string parameter_switch) {
 }
 
 bool Commandlineparser::getBoolParameter(std::string parameter_switch) {
-  return getParameter(parameter_switch) != 0;
+  return getParameter(parameter_switch) != nullptr;
 }
 
 void Commandlineparser::parse(int& argc, const char* argv[]) {
@@ -72,7 +72,7 @@ void Commandlineparser::parse(int& argc, const char* argv[]) {
     auto it = params_.find(std::string (argv[i]));
     if (it == params_.end())
       print_fatal_error(std::string("Invalid parameter '") + argv[i] + "'!");
-    if (it->second.defaultvalue != 0) {
+    if (it->second.defaultvalue != nullptr) {
       ++i;
       if(i >= argc)
         print_fatal_error(std::string("Parameter for switch '") + argv[i-1] + "' is missing!");
@@ -89,7 +89,7 @@ void Commandlineparser::print_pars() {
     std::string pad = "  ";
     for (unsigned l = maxlen_; l >= par.name.length(); l--)
       pad += " ";
-    std::string defaulttext = (par.defaultvalue == 0) ? "" : std::string(" (default '") + par.defaultvalue + "')";
+    std::string defaulttext = (par.defaultvalue == nullptr) ? "" : std::string(" (default '") + par.defaultvalue + "')";
     std::cout << par.name << pad << par.helptext << defaulttext << std::endl;
   }
 }

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, const char* argv[]) {
   args.addParameter("-i",    "characteristic input file", "examples/ascon_3_rounds_typeI.xml");
   args.addParameter("-u",    "requested function: checkchar, search", "search");
 
-  args.addParameter("-h",    "display help", 0);
+  args.addParameter("-h",    "display help", nullptr);
 
   args.parse(argc, argv);
 


### PR DESCRIPTION
The override problems have been reported by the compiler itself. The nullptr fixes on the other hand are the result of clang-tidy. I also tried scan-build but could not find any issues.

I can further provide you with a simple CMakeLists.txt which I used to generate the compilation database for clang-tidy if you are interested.

Regards,
Mario
